### PR TITLE
URL update Wolfenbuettel

### DIFF
--- a/data/countries/de/ni/data.yaml
+++ b/data/countries/de/ni/data.yaml
@@ -2310,7 +2310,7 @@ state: Niedersachsen
 district: Wolfenbüttel
 urls:
   - type: WEBSITE
-    url: http://www.gruene-wf.de/
+    url: https://www.xn--grne-wf-o2a.de/
 ---
 type: REGIONAL_CHAPTER
 level: DE:ORTSVERBAND


### PR DESCRIPTION
http://www.gruene-wf.de/ redirects to https://www.xn--grne-wf-o2a.de/startseite/ , thus we use https://www.xn--grne-wf-o2a.de/