### PR TITLE
URL update for Paderborn

### DIFF
--- a/data/countries/de/nw/data.yaml
+++ b/data/countries/de/nw/data.yaml
@@ -315,7 +315,7 @@ state: Nordrhein-Westfalen
 type: REGIONAL_CHAPTER
 urls:
   - type: WEBSITE
-    url: http://www.padergruen.de
+    url: https://www.xn--padergrn-d6a.de/
   - type: FACEBOOK
     url: https://www.facebook.com/Gruene.Paderborn
   - type: TWITTER


### PR DESCRIPTION
http://www.padergruen.de/ redirects to https://www.xn--padergrn-d6a.de/