### PR TITLE
Add OV Nenndorf, moved KV Schaumburg and subs to own file

### DIFF
--- a/data/countries/de/ni/data.yaml
+++ b/data/countries/de/ni/data.yaml
@@ -191,29 +191,6 @@ type: REGIONAL_CHAPTER
 level: DE:KREISVERBAND
 country: DE
 state: Niedersachsen
-district: Schaumburg
-urls:
-  - type: WEBSITE
-    url: http://www.gruene-schaumburg.de/
----
-type: REGIONAL_CHAPTER
-level: DE:ORTSVERBAND
-country: DE
-state: Niedersachsen
-district: Schaumburg
-city: Bückeburg
-urls:
-  - type: WEBSITE
-    url: http://www.gruene-bueckeburg.de/
-  - type: TWITTER
-    url: https://twitter.com/G_Bueckeburg
-  - type: FACEBOOK
-    url: https://www.facebook.com/Gr%C3%BCne-B%C3%BCckeburg-1544235625804377/
----
-type: REGIONAL_CHAPTER
-level: DE:KREISVERBAND
-country: DE
-state: Niedersachsen
 district: Uelzen
 urls:
   - type: WEBSITE

--- a/data/countries/de/ni/schaumburg/data.yaml
+++ b/data/countries/de/ni/schaumburg/data.yaml
@@ -1,0 +1,33 @@
+---
+type: REGIONAL_CHAPTER
+level: DE:KREISVERBAND
+country: DE
+state: Niedersachsen
+district: Schaumburg
+urls:
+  - type: WEBSITE
+    url: http://www.gruene-schaumburg.de/
+---
+type: REGIONAL_CHAPTER
+level: DE:ORTSVERBAND
+country: DE
+state: Niedersachsen
+district: Schaumburg
+city: Bückeburg
+urls:
+  - type: WEBSITE
+    url: http://www.gruene-bueckeburg.de/
+  - type: TWITTER
+    url: https://twitter.com/G_Bueckeburg
+  - type: FACEBOOK
+    url: https://www.facebook.com/Gr%C3%BCne-B%C3%BCckeburg-1544235625804377/
+---
+type: REGIONAL_CHAPTER
+level: DE:ORTSVERBAND
+country: DE
+state: Niedersachen
+district: Schaumburg
+city: Nenndorf
+urls:
+  - type: WEBSITE
+    url: http://www.gruene-nenndorf.de/

--- a/data/countries/de/ni/schaumburg/data.yaml
+++ b/data/countries/de/ni/schaumburg/data.yaml
@@ -16,7 +16,7 @@ district: Schaumburg
 city: Bückeburg
 urls:
   - type: WEBSITE
-    url: http://www.gruene-bueckeburg.de/
+    url: https://gruene-schaumburg.de/stadtverband-bueckeburg/
   - type: TWITTER
     url: https://twitter.com/G_Bueckeburg
   - type: FACEBOOK


### PR DESCRIPTION
Have not been too sure about in which cases a Kreisverband should get its own directory and `data.yaml` file, but it seemed to be fitting here with the second OV added.