### PR TITLE
Changed DE:ORTSVERBAND ulr to SSL HTTPS

### DIFF
--- a/data/countries/de/by/erlangen-land/data.yaml
+++ b/data/countries/de/by/erlangen-land/data.yaml
@@ -18,7 +18,7 @@ state: Bayern
 type: REGIONAL_CHAPTER
 urls:
   - type: WEBSITE
-    url: http://gruene-bubenreuth.de/
+    url: https://gruene-bubenreuth.de/
 ---
 city: Herzogenaurach
 country: DE


### PR DESCRIPTION
WebSite www.gruene-bubenreuth.de has been changed to SSL/HTTPS protocol.
Adapted data file accordingly to https://www.gruene-bubenreuth.de
---
city: Bubenreuth
country: DE
district: Erlangen-Land
level: DE:ORTSVERBAND
state: Bayern
type: REGIONAL_CHAPTER
 - type: WEBSITE
    url: https://gruene-bubenreuth.de/
---